### PR TITLE
Add resizing support and sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ A simple chess interface written in Python. The GUI is powered by **pygame** and
 - Click on a piece to select it and click on a valid destination to move.
 - Highlights possible moves for the selected piece.
 - Press **R** to reset the board at any time.
+- Dark squares are now green.
+- The board scales when resizing the window.
+- A sidebar provides placeholder options for future features.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- change dark squares to green
- make board resizable and window resizable
- add placeholder sidebar for options
- update README with new features

## Testing
- `pip install pygame python-chess`
- `python gui.py` *(fails to run in headless mode after launching, but starts until interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6841377accd08329bf65d1c367d849b5