### PR TITLE
Fix engine analysis import error

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -290,7 +290,7 @@ class ChessGUI:
             analysis_board = self.board.copy()
             board_len = len(analysis_board.move_stack)
             try:
-                with self.engine.analysis(analysis_board, chess.engine.Limit(infinite=True)) as analysis:
+                with self.engine.analysis(analysis_board, chess.engine.Limit()) as analysis:
                     for info in analysis:
                         if not self.analysis_running:
                             analysis.stop()


### PR DESCRIPTION
## Summary
- remove unsupported `infinite` arg when starting engine analysis

## Testing
- `python -m py_compile THE-Chess-GUI/gui.py`


------
https://chatgpt.com/codex/tasks/task_e_6841447ff0ac83299eb04594b372249a